### PR TITLE
Allow build with vector 0.10.*

### DIFF
--- a/lushtags.cabal
+++ b/lushtags.cabal
@@ -54,6 +54,6 @@ executable lushtags
   default-language:  Haskell98
   ghc-options:       -Wall
   build-depends:     base >= 4 && < 5,
-                     vector == 0.9.*,
+                     vector >= 0.9 && < 0.11,
                      text == 0.11.*,
                      haskell-src-exts >= 1.11.1 && < 1.14


### PR DESCRIPTION
Here you go. I've limited the version from above because I guess it's better to add explicit 0.11.\* support and beyond if they are released than to have build errors.
