### PR TITLE
Bumped maximum haskell-src-ext version to 1.14 in .cabal

### DIFF
--- a/lushtags.cabal
+++ b/lushtags.cabal
@@ -56,4 +56,4 @@ executable lushtags
   build-depends:     base >= 4 && < 5,
                      vector >= 0.9 && < 0.11,
                      text == 0.11.*,
-                     haskell-src-exts >= 1.11.1 && < 1.14
+                     haskell-src-exts >= 1.11.1 && < 1.15


### PR DESCRIPTION
It builds fine with lushtags-1.14.0
