### PR TITLE
lushtags.cabal: allow text-1.1

### DIFF
--- a/lushtags.cabal
+++ b/lushtags.cabal
@@ -55,5 +55,5 @@ executable lushtags
   ghc-options:       -Wall
   build-depends:     base >= 4 && < 5,
                      vector >= 0.9 && < 0.11,
-                     text == 0.11.*,
+                     text >= 0.11 && < 1.2,
                      haskell-src-exts >= 1.11.1 && < 1.15


### PR DESCRIPTION
Signed-off-by: Sergei Trofimovich slyfox@gentoo.org
