### PR TITLE
bumped versions of dependencies to build with ghc 7.8 and current libs

### DIFF
--- a/lushtags.cabal
+++ b/lushtags.cabal
@@ -55,5 +55,5 @@ executable lushtags
   ghc-options:       -Wall
   build-depends:     base >= 4 && < 5,
                      vector >= 0.9 && < 0.11,
-                     text == 0.11.*,
+                     text >= 0.11 && < 1.1.1,
                      haskell-src-exts >= 1.11.1 && < 1.15


### PR DESCRIPTION
I think the title is clear enough :)   I built it with ghc 7.8.2 and current platform...
