### PR TITLE
Add support for current libraries and build project with Stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist/
+.stack-work/

--- a/lushtags.cabal
+++ b/lushtags.cabal
@@ -54,6 +54,6 @@ executable lushtags
   default-language:  Haskell98
   ghc-options:       -Wall
   build-depends:     base >= 4 && < 5,
-                     vector >= 0.9 && < 0.11,
-                     text == 0.11.*,
-                     haskell-src-exts >= 1.11.1 && < 1.15
+                     vector >= 0.9 && < 0.12,
+                     text >= 1.2,
+                     haskell-src-exts >= 1.17

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -59,6 +59,7 @@ processFile file ignore_parse_error = do
             , ignoreLanguagePragmas = False
             , ignoreLinePragmas = True
             , fixities = Nothing
+            , ignoreFunctionArity = False
             }
 
 loadFile :: FilePath -> IO (String, Vector String)

--- a/src/Tags.hs
+++ b/src/Tags.hs
@@ -150,7 +150,7 @@ createModuleTags (ModuleHead _ (ModuleName moduleLoc moduleName) _ mbExportSpecL
             in createTag name TExport Nothing Nothing Nothing loc
 
 createImportTag :: ImportDecl SrcSpanInfo -> TagC
-createImportTag (ImportDecl loc (ModuleName _ name) qualified _ _ mbAlias mbSpecs) =
+createImportTag (ImportDecl loc (ModuleName _ name) qualified _ _ _ mbAlias mbSpecs) =
     let signature = case mbAlias of
             Nothing -> Nothing
             Just (ModuleName _ alias) -> Just alias
@@ -192,15 +192,16 @@ createConstructorTag parent (QualConDecl _ _ _ con) =
 
 extractExportSpec :: ExportSpec SrcSpanInfo -> (String, SrcSpanInfo)
 extractExportSpec (EVar _ name) = extractQName name
-extractExportSpec (EAbs _ name) = extractQName name
+extractExportSpec (EAbs _ _ name) = extractQName name
 extractExportSpec (EThingAll _ name) = extractQName name
 extractExportSpec (EThingWith _ name _) = extractQName name
 extractExportSpec (EModuleContents _ (ModuleName loc name)) = (name, loc)
 
 extractDeclHead :: DeclHead SrcSpanInfo -> (String, SrcSpanInfo)
-extractDeclHead (DHead _ name _) = extractName name
-extractDeclHead (DHInfix _ _ name _) = extractName name
+extractDeclHead (DHead _ name) = extractName name
+extractDeclHead (DHInfix _ _ name) = extractName name
 extractDeclHead (DHParen _ hd') = extractDeclHead hd'
+extractDeclHead (DHApp _ hd' _) = extractDeclHead hd'
 
 extractConDecl :: ConDecl SrcSpanInfo -> (String, SrcSpanInfo)
 extractConDecl (ConDecl _ name _) = extractName name

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,1 @@
+resolver: lts-5.9


### PR DESCRIPTION
I really like this project, so I updated its dependencies and added the capability to build the project with stack (against the resolver `5.9.`). It would be awesome if you can take a look at the changes and upload the package to `hackage` and `stackage`. If I can help you with something, just let me know it.
Thanks in advance.