### PR TITLE
Support default extensions as -XSomeExt arguments

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+[*.hs]
+indent_style = space
+indent_size = 4

--- a/lushtags.cabal
+++ b/lushtags.cabal
@@ -54,6 +54,6 @@ executable lushtags
   default-language:  Haskell98
   ghc-options:       -Wall
   build-depends:     base >= 4 && < 5,
-                     vector >= 0.9 && < 0.12,
-                     text >= 1.2,
-                     haskell-src-exts >= 1.18
+                     vector >= 0.9 && < 0.13,
+                     text >= 1.2 && < 2,
+                     haskell-src-exts >= 1.18 && < 2

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -12,40 +12,76 @@
 --
 -----------------------------------------------------------------------------
 
+{-# LANGUAGE LambdaCase #-}
+
 module Main (main) where
 
-import Data.List (isPrefixOf, partition)
-import Data.Vector(Vector, fromList)
-import Language.Haskell.Exts (parseFileContentsWithMode, ParseMode(..), knownExtensions, ParseResult(ParseOk, ParseFailed))
-import Language.Haskell.Exts.Extension (Language(..))
+import Data.List (isPrefixOf, partition, intercalate)
+import Data.Vector (Vector, fromList)
+import Language.Haskell.Exts (parseFileContentsWithMode)
+import Language.Haskell.Exts.Parser ( ParseMode (..)
+                                    , ParseResult (ParseOk, ParseFailed)
+                                    )
+import Language.Haskell.Exts.Extension ( Language (..)
+                                       , Extension (UnknownExtension)
+                                       , classifyExtension
+                                       )
 import System.Environment (getArgs, getProgName)
 import System.IO (hPutStrLn, stderr)
 import qualified Data.Text as T (unpack, lines, pack, unlines)
 import qualified Data.Text.IO as T (readFile, putStr)
+import Control.Monad (unless)
 
 import Tags (Tag, createTags, tagToString)
+
+
+data ParseOptions
+    = ParseOptions
+    { ignoreParseError     :: Bool
+    , predefinedExtensions :: [Extension]
+    } deriving (Show, Eq)
+
 
 main :: IO ()
 main = do
     rawArgs <- getArgs
+
     let (options, files) = getOptions rawArgs
-        ignore_parse_error = "--ignore-parse-error" `elem` options
+
+        parseOpts
+          = ParseOptions
+          { ignoreParseError = "--ignore-parse-error" `elem` options
+
+          , predefinedExtensions = [ classifyExtension (drop 2 opt)
+                                   | opt <- options
+                                   , take 2 opt == "-X"
+                                   ]
+          }
+
     case files of
         [] -> do
             progName <- getProgName
             hPutStrLn stderr $ "Usage: " ++ progName ++ " [options] [--] <file>"
-        filename:_ -> processFile filename ignore_parse_error >>= printTags
+        filename:_ -> do
+            let unknownExts =
+                    foldr (\case UnknownExtension x -> (x :) ; _ -> id) []
+                        $ predefinedExtensions parseOpts
+
+            unless (null unknownExts) $
+                error $ "Unknown extensions: " ++ intercalate ", " unknownExts
+
+            processFile filename parseOpts >>= printTags
 
 printTags :: [Tag] -> IO ()
 printTags tags =
     T.putStr $ T.unlines $ map (T.pack . tagToString) tags
 
-processFile :: FilePath -> Bool -> IO [Tag]
-processFile file ignore_parse_error = do
+processFile :: FilePath -> ParseOptions -> IO [Tag]
+processFile file opts = do
     (fileContents, fileLines) <- loadFile file
     case parseFileContentsWithMode parseMode fileContents of
         ParseFailed loc message ->
-            if ignore_parse_error then
+            if ignoreParseError opts then
                 return []
             else
                 -- TODO Better error reporting
@@ -55,7 +91,7 @@ processFile file ignore_parse_error = do
         parseMode = ParseMode
             { parseFilename = file
             , baseLanguage = Haskell2010
-            , extensions = knownExtensions
+            , extensions = predefinedExtensions opts
             , ignoreLanguagePragmas = False
             , ignoreLinePragmas = True
             , fixities = Nothing

--- a/src/Tags.hs
+++ b/src/Tags.hs
@@ -14,15 +14,19 @@
 
 module Tags
     (
-      Tag(..)
+      Tag (..)
     , createTags
     , tagToString
     ) where
 
-import Data.Vector(Vector, (!))
-import Language.Haskell.Exts (SrcSpan(..), SrcSpanInfo(..))
+import Data.Vector (Vector, (!))
+import Language.Haskell.Exts.SrcLoc (SrcSpan (..), SrcSpanInfo (..))
 import Language.Haskell.Exts.Syntax
-import Language.Haskell.Exts.Pretty (prettyPrintStyleMode, Style(..), Mode(OneLineMode), defaultMode)
+import Language.Haskell.Exts.Pretty ( prettyPrintStyleMode
+                                    , Style (..)
+                                    , Mode (OneLineMode)
+                                    , defaultMode
+                                    )
 
 data Tag = Tag
     { tagName :: String
@@ -123,8 +127,16 @@ applyAccessModifiers exportTags declTags = map applySingle declTags
                 then tag { tagAccess = Just AccessPublic }
                 else tag
 
-createTag :: String -> TagKind -> Maybe (TagKind, String) -> Maybe String -> Maybe TagAccess -> SrcSpanInfo -> TagC
-createTag name kind parent signature access (SrcSpanInfo (SrcSpan file line _ _ _) _) fileLines = Tag
+createTag :: String
+          -> TagKind
+          -> Maybe (TagKind, String)
+          -> Maybe String
+          -> Maybe TagAccess
+          -> SrcSpanInfo
+          -> TagC
+createTag
+  name kind parent signature access
+  (SrcSpanInfo (SrcSpan file line _ _ _) _) fileLines = Tag
     { tagName = name
     , tagFile = file
     -- TODO This probably needs to be escaped:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,2 @@
-resolver: lts-8.8
+resolver: lts-10.0
+system-ghc: false


### PR DESCRIPTION
@bitc 
Support pre-enabled extensions by `-XSomeExtension` arguments.

**Also:**
- Support [GHC 8.2.2](https://www.stackage.org/lts-10.0) (using `lts-10.0`)
- Added `.editorconfig` (see [editorconfig.org](http://editorconfig.org/))